### PR TITLE
allow optionally passing a model file to ArcFace

### DIFF
--- a/arcface/ArcFace.py
+++ b/arcface/ArcFace.py
@@ -23,12 +23,15 @@ import numpy as np
 import cv2
 import os
 import requests
-from astropy.utils.data import download_file
 
 class ArcFace():
-    def __init__(self): 
-        tflite_path = download_file("https://cloud.ins.jku.at/index.php/s/g2YDT8Zn9RkzsEy/download", cache=True) 
-        
+    def __init__(self, model_path = None):
+        if model_path == None:
+            from astropy.utils.data import download_file
+            tflite_path = download_file("https://cloud.ins.jku.at/index.php/s/g2YDT8Zn9RkzsEy/download", cache=True)
+        else:
+            tflite_path = model_path
+
         self.interpreter = tf.lite.Interpreter(model_path=tflite_path)
         self.interpreter.allocate_tensors()
         self.input_details = self.interpreter.get_input_details()

--- a/arcface/requirements.txt
+++ b/arcface/requirements.txt
@@ -1,1 +1,0 @@
-tensorflow==2.3.1

--- a/setup.py
+++ b/setup.py
@@ -31,14 +31,21 @@ setuptools.setup(
     url="https://github.com/mobilesec/arcface-tensorflowlight",
     packages=setuptools.find_packages(exclude=["tests.*", "tests"]),
     install_requires=[
-          "tensorflow>=2.0.0",
+          "tensorflow>=2.3.0",
           "pyyaml>=5.3",
           "opencv-python>=4.4",
           "numpy",
           "requests>=2.24.0",
-          "astropy"
       ],
-    tests_require=['pytest'],  
+    extras_require = {
+          'testing': [
+                "pytest-runner",
+                "pytest"
+             ],
+          'default_model': [
+              "astropy"
+            ]
+      },
     license="European Union Public Licence 1.2 (EUPL 1.2)",
     classifiers=[
         "License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)",


### PR DESCRIPTION
* If a model file is passed as a constructor argument ArcFace,
  ArcFace will use that model file. If not the previous behavior is
  retained. This means ArcFace will use astropy to download a specific
  default model file.
* Since astropy is not required for all usages of astropy,
  it is made an optional dependency.
* Express testing dependencies as optional dependenices as well.
* Remove unmaintained overly-specific requirements.txt file.
* Be more strict about required TensorFlow versions.