### PR TITLE
add nix flake-based build for testing

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,88 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1618217525,
+        "narHash": "sha256-WGrhVczjXTiswQaoxQ+0PTfbLNeOQM6M36zvLn78AYg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c6169a2772643c4a93a0b5ac1c61e296cba68544",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pypi-deps-db": [
+          "pypi-deps-db"
+        ]
+      },
+      "locked": {
+        "lastModified": 1615528021,
+        "narHash": "sha256-FSzp2qrHMhyiVr7K2wGdBeqf5HWGDCouuCYGNqgZD2I=",
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "rev": "ac62255e8112e547432ca0f09bfe8f4d1920fbb8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "ref": "3.2.0",
+        "repo": "mach-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1618801528,
+        "narHash": "sha256-1ru9LzP33ElEAZcDzYLgJQG3/uHhAg0LFJEfVZSOPZg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0a5f5bab0e08e968ef25cff393312aa51a3512cf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pypi-deps-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1618819705,
+        "narHash": "sha256-BqAX8CAKSgtC/advZ3hra6wQqANWc1ZUboHq1H2s5Fo=",
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "rev": "32bff392d43426cc252617bbebb3234244952362",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "mach-nix": "mach-nix",
+        "nixpkgs": "nixpkgs",
+        "pypi-deps-db": "pypi-deps-db"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,11 @@
   flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
   let
     pkgs = import nixpkgs { inherit system; };
-    mach-nix-utils = import mach-nix { inherit pkgs; };
+    mach-nix-utils = import mach-nix {
+      inherit pkgs;
+      pypiDataRev = pypi-deps-db.rev;
+      pypiDataSha256 = pypi-deps-db.narHash;
+    };
     model-url = "https://cloud.ins.jku.at/index.php/s/g2YDT8Zn9RkzsEy/download";
     model-file = builtins.fetchurl {
       url = model-url;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "ArcFace face recognition algorithm implementation for TensorFlow Lite";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    pypi-deps-db = {
+      url = "github:DavHau/pypi-deps-db";
+      flake = false;
+    };
+    mach-nix = {
+      url = "github:DavHau/mach-nix/3.2.0";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+      inputs.pypi-deps-db.follows = "pypi-deps-db";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, mach-nix, pypi-deps-db }:
+  flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
+  let
+    pkgs = import nixpkgs { inherit system; };
+    mach-nix-utils = import mach-nix { inherit pkgs; };
+    model-url = "https://cloud.ins.jku.at/index.php/s/g2YDT8Zn9RkzsEy/download";
+    model-file = builtins.fetchurl {
+      url = model-url;
+      sha256 = "1vqvabkcada770mqyaxa91bhd24zaqam48n8z7fi76j7mf3sf3kh";
+    };
+  in {
+
+    packages.arcface-tflite = mach-nix-utils.buildPythonPackage {
+      src = ./.;
+      extras = [ "testing" "default_model" ];
+      tests = true;
+      preCheck = ''
+        tmp_dir=$(mktemp -d)
+        model_dir="$tmp_dir/.astropy/cache/download/url/${builtins.hashString "md5" model-url}"
+        mkdir -p $model_dir
+        cp ${model-file} "$model_dir/contents"
+        echo -n "${model-url}" > "$model_dir/url"
+        export HOME=$tmp_dir
+     '';
+    };
+
+    defaultPackage = self.packages.${system}.arcface-tflite;
+  });
+}


### PR DESCRIPTION
You can run this as
```
nix build
```
before creating a release to make sure all of the dependencies can be resolved and the tests run in Nix.

It also runs the tests, which is why it includes
```
extras = [ "testing" "default_model" ];
```
so that it can get the model for the tests via `astropy`.

But since the tests don't have internet access I still pass the actual model file in via Nix and put it in the place where astropy expects it using the code inside the `preCheck` hook.