### PR TITLE
remove mach-nix from nix build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,40 +15,13 @@
         "type": "github"
       }
     },
-    "mach-nix": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "pypi-deps-db": [
-          "pypi-deps-db"
-        ]
-      },
-      "locked": {
-        "lastModified": 1615528021,
-        "narHash": "sha256-FSzp2qrHMhyiVr7K2wGdBeqf5HWGDCouuCYGNqgZD2I=",
-        "owner": "DavHau",
-        "repo": "mach-nix",
-        "rev": "ac62255e8112e547432ca0f09bfe8f4d1920fbb8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "DavHau",
-        "ref": "3.2.0",
-        "repo": "mach-nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1618801528,
-        "narHash": "sha256-1ru9LzP33ElEAZcDzYLgJQG3/uHhAg0LFJEfVZSOPZg=",
+        "lastModified": 1647350163,
+        "narHash": "sha256-OcMI+PFEHTONthXuEQNddt16Ml7qGvanL3x8QOl2Aao=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0a5f5bab0e08e968ef25cff393312aa51a3512cf",
+        "rev": "3eb07eeafb52bcbf02ce800f032f18d666a9498d",
         "type": "github"
       },
       "original": {
@@ -58,28 +31,10 @@
         "type": "github"
       }
     },
-    "pypi-deps-db": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1618819705,
-        "narHash": "sha256-BqAX8CAKSgtC/advZ3hra6wQqANWc1ZUboHq1H2s5Fo=",
-        "owner": "DavHau",
-        "repo": "pypi-deps-db",
-        "rev": "32bff392d43426cc252617bbebb3234244952362",
-        "type": "github"
-      },
-      "original": {
-        "owner": "DavHau",
-        "repo": "pypi-deps-db",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "mach-nix": "mach-nix",
-        "nixpkgs": "nixpkgs",
-        "pypi-deps-db": "pypi-deps-db"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,40 +2,27 @@
   description = "ArcFace face recognition algorithm implementation for TensorFlow Lite";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-    pypi-deps-db = {
-      url = "github:DavHau/pypi-deps-db";
-      flake = false;
-    };
-    mach-nix = {
-      url = "github:DavHau/mach-nix/3.2.0";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-      inputs.pypi-deps-db.follows = "pypi-deps-db";
-    };
+    nixpkgs.url = github:nixos/nixpkgs/nixos-unstable;
+    flake-utils.url = github:numtide/flake-utils;
   };
 
-  outputs = { self, nixpkgs, flake-utils, mach-nix, pypi-deps-db }:
+  outputs = { self, nixpkgs, flake-utils }:
   flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
   let
     pkgs = import nixpkgs { inherit system; };
-    mach-nix-utils = import mach-nix {
-      inherit pkgs;
-      pypiDataRev = pypi-deps-db.rev;
-      pypiDataSha256 = pypi-deps-db.narHash;
-    };
     model-url = "https://cloud.ins.jku.at/index.php/s/g2YDT8Zn9RkzsEy/download";
     model-file = builtins.fetchurl {
       url = model-url;
       sha256 = "1vqvabkcada770mqyaxa91bhd24zaqam48n8z7fi76j7mf3sf3kh";
     };
+    pythonPackages = pkgs.python39Packages;
   in {
 
-    packages.arcface-tflite = mach-nix-utils.buildPythonPackage {
+    packages.arcface-tflite = pythonPackages.buildPythonPackage {
+      pname = "arcface";
+      version = "0.0.8";
       src = ./.;
-      extras = [ "testing" "default_model" ];
-      tests = true;
+      checkInputs = with pythonPackages; [ pytest pytest-runner astropy ];
       preCheck = ''
         tmp_dir=$(mktemp -d)
         model_dir="$tmp_dir/.astropy/cache/download/url/${builtins.hashString "md5" model-url}"
@@ -43,7 +30,16 @@
         cp ${model-file} "$model_dir/contents"
         echo -n "${model-url}" > "$model_dir/url"
         export HOME=$tmp_dir
-     '';
+      '';
+      # stop pathcing opencv package name once this is fixed: https://github.com/NixOS/nixpkgs/issues/157397
+      postPatch = ''
+        sed -i 's/opencv-python/opencv/' setup.py
+      '';
+      propagatedBuildInputs = with pythonPackages; [ numpy pyyaml tensorflow keras opencv4 ];
+      meta = with pkgs.lib; {
+        homepage = "https://github.com/mobilesec/arcface-tensorflowlite";
+        license = licenses.eupl12;
+      };
     };
 
     defaultPackage = self.packages.${system}.arcface-tflite;


### PR DESCRIPTION
Doing the build manually with nix turned out to be easier to maintain than using mach-nix.

Merging this PR does not warrant publishing a new release, since we do not use the nix build for releases.